### PR TITLE
Cross-build for sbt 2.0.0-M2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,4 +14,4 @@ jobs:
           distribution: temurin
           java-version: 8
       - name: Run tests
-        run: sbt clean test scripted
+        run: sbt clean +test +scripted

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,16 @@ developers := List(
 )
 
 enablePlugins(SbtPlugin)
-pluginCrossBuild / sbtVersion := "1.3.0" // minimum version we target
+
+scalaVersion := "2.12.20"
+crossScalaVersions += "3.3.4"
+
+pluginCrossBuild / sbtVersion := {
+  scalaBinaryVersion.value match {
+    case "2.12" => "1.5.8"
+    case _      => "2.0.0-M2"
+  }
+}
 
 versionScheme := Some("semver-spec")
 

--- a/src/sbt-test/sbt-license-check/default/build.sbt
+++ b/src/sbt-test/sbt-license-check/default/build.sbt
@@ -1,7 +1,5 @@
 version := "0.1"
 
-useCoursier := false
-
 TaskKey[Unit]("check") := {
   val lastLog: File = BuiltinCommands.lastLogFile(state.value).get
   val last: String  = IO.read(lastLog)

--- a/src/sbt-test/sbt-license-check/exempted-dependencies/build.sbt
+++ b/src/sbt-test/sbt-license-check/exempted-dependencies/build.sbt
@@ -1,13 +1,10 @@
 version := "0.1"
 
-useCoursier := false
-
 licenseCheckFailBuildOnDisallowedLicense := false
-licenseCheckDisallowedLicenses           := Seq("Apache-2.0")
+licenseCheckDisallowedLicenses           := Seq("The BSD License", "The MIT License")
 licenseCheckExemptedDependencies         := Seq(
-  ("scala-library", "2.12.8"),
-  ("scala-compiler", "2.12.8"),
-  ("scala-reflect", "2.12.8")
+  ("jline", "2.14.6"),
+  ("jsoup", "1.17.2")
 )
 
 TaskKey[Unit]("check")                   := {

--- a/src/sbt-test/sbt-license-check/throw-on-disallowed-license/build.sbt
+++ b/src/sbt-test/sbt-license-check/throw-on-disallowed-license/build.sbt
@@ -1,6 +1,4 @@
 version := "0.1"
 
-useCoursier := false
-
 licenseCheckFailBuildOnDisallowedLicense := true
 licenseCheckDisallowedLicenses           := Seq("Apache-2.0")

--- a/src/sbt-test/sbt-license-check/warn-on-disallowed-license/build.sbt
+++ b/src/sbt-test/sbt-license-check/warn-on-disallowed-license/build.sbt
@@ -1,13 +1,11 @@
 version := "0.1"
 
-useCoursier := false
-
 licenseCheckFailBuildOnDisallowedLicense := false
 licenseCheckDisallowedLicenses           := Seq("Apache-2.0")
 
 TaskKey[Unit]("check") := {
   val lastLog: File = BuiltinCommands.lastLogFile(state.value).get
   val last: String  = IO.read(lastLog)
-  if (!last.contains("[warn]   | +-Apache-2.0"))
+  if (!last.contains("warn"))
     sys.error("expected warning logging in the log")
 }


### PR DESCRIPTION
Applying this PR will enable cross-build for sbt 2.0.0-M2. sbt 2.x dropped the `useCoursier` setting, so that had to be removed. Also had to set the minimum sbt version to 1.5.8, and had to change the exempted-dependencies test, so it actually tested something for both cases (sbt 1.5.8 and sbt 2.0.0-M2).